### PR TITLE
Add issue template for enhancement proposal

### DIFF
--- a/.github/ISSUE_TEMPLATE/keptn-enhancement-proposal.md
+++ b/.github/ISSUE_TEMPLATE/keptn-enhancement-proposal.md
@@ -1,0 +1,54 @@
+---
+name: Keptn Enhancement Proposal
+about: Create a Keptn Enhancement Proposal as an Issue
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+# Replace this with your awesome KEP title
+
+Short (one sentence) summary, e.g., something that would be appropriate for a [CHANGELOG](https://keepachangelog.com/) or release notes.
+
+## Motivation
+
+Why should we make this change? What new value would it bring? What use cases does it enable?
+
+## Explanation
+
+Explain the proposed change as though it was already implemented and you were explaining it to a user. Depending on which layer the proposal addresses, the "user" may vary, or there may even be multiple.
+
+We encourage you to use examples, diagrams, or whatever else makes the most sense!
+
+## Internal details
+
+From a technical perspective, how do you propose accomplishing the proposal? In particular, please explain:
+
+* How the change would impact and interact with existing functionality
+* Likely error modes (and how to handle them)
+* Corner cases (and how to handle them)
+
+While you do not need to prescribe a particular implementation - indeed, KEPs should be about **behaviour**, not implementation! - it may be useful to provide at least one suggestion as to how the proposal *could* be implemented. This helps reassure reviewers that implementation is at least possible, and often helps them inspire them to think more deeply about trade-offs, alternatives, etc.
+
+## Trade-offs and mitigations
+
+What are some (known!) drawbacks? What are some ways that they might be mitigated?
+
+Note that mitigations do not need to be complete *solutions*, and that they do not need to be accomplished directly through your proposal. A suggested mitigation may even warrant its own KEP!
+
+## Breaking changes
+
+Could this proposal cause any breaking changes (e.g., in the spec, within any workflows)?
+
+## Prior art and alternatives
+
+What are some prior and/or alternative approaches? For instance, is there a corresponding feature in OpenTracing or OpenCensus? What are some ideas that you have rejected?
+
+## Open questions
+
+What are some questions that you know aren't resolved yet by the KEP? These may be questions that could be answered through further discussion, implementation experiments, or anything else that the future may bring.
+
+## Future possibilities
+
+What are some future changes that this proposal would enable?

--- a/.github/ISSUE_TEMPLATE/keptn-enhancement-proposal.md
+++ b/.github/ISSUE_TEMPLATE/keptn-enhancement-proposal.md
@@ -4,50 +4,55 @@ about: Create a Keptn Enhancement Proposal as an Issue
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
-# Replace this with your awesome KEP title
+# REPLACE this with your KEP title
 
-Short (one sentence) summary, e.g., something that would be appropriate for a [CHANGELOG](https://keepachangelog.com/) or release notes.
+Short one-sentence summary, i.e., a sentence that would be appropriate for a [CHANGELOG](https://keepachangelog.com/) or release note.
 
 ## Motivation
 
-Why should we make this change? What new value would it bring? What use cases does it enable?
+* Which use-cases does this KEP enable?
+* Which value would this KEP create?
 
 ## Explanation
 
-Explain the proposed change as though it was already implemented and you were explaining it to a user. Depending on which layer the proposal addresses, the "user" may vary, or there may even be multiple.
-
-We encourage you to use examples, diagrams, or whatever else makes the most sense!
+Explain the proposed change as though it was already implemented and you were explaining it to a user. Depending on which layer the proposal addresses, the "user" may vary or there may even be multiple.
+We encourage you to use examples, diagrams, or whatever else helps to explain the proposal.
 
 ## Internal details
 
-From a technical perspective, how do you propose accomplishing the proposal? In particular, please explain:
+From a technical perspective, how do you propose accomplishing the proposal? 
 
-* How the change would impact and interact with existing functionality
-* Likely error modes (and how to handle them)
-* Corner cases (and how to handle them)
+In particular, please explain:
 
-While you do not need to prescribe a particular implementation - indeed, KEPs should be about **behaviour**, not implementation! - it may be useful to provide at least one suggestion as to how the proposal *could* be implemented. This helps reassure reviewers that implementation is at least possible, and often helps them inspire them to think more deeply about trade-offs, alternatives, etc.
+* How would the change impact and interact with existing functionality?
+* Likely error modes and how to handle them
+* Corner cases and how to handle them
+
+While you do not need to prescribe a particular implementation - a KEP should be about **behavior**, not the implementation - it may be useful to provide at least one suggestion as to how the proposal *could* be implemented. This helps reassure reviewers that implementation is at least possible, and often helps them thinking more deeply about trade-offs, alternatives, etc.
 
 ## Trade-offs and mitigations
 
-What are some (known!) drawbacks? What are some ways that they might be mitigated?
+* What are some (known) drawbacks? 
+* What are some ways that they might be mitigated?
 
-Note that mitigations do not need to be complete *solutions*, and that they do not need to be accomplished directly through your proposal. A suggested mitigation may even warrant its own KEP!
+Note that mitigations do not need to be complete *solutions* and they do not need to be accomplished directly through your proposal. A suggested mitigation may even warrant its own KEP.
 
 ## Breaking changes
 
-Could this proposal cause any breaking changes (e.g., in the spec, within any workflows)?
+Could this proposal cause any breaking changes (e.g., in the spec or within any workflow)?
 
 ## Prior art and alternatives
 
-What are some prior and/or alternative approaches? For instance, is there a corresponding feature in OpenTracing or OpenCensus? What are some ideas that you have rejected?
+* What are some prior and/or alternative approaches? E.g., is there a corresponding feature in OpenTracing or OpenCensus? 
+* What are some ideas that you have rejected?
 
 ## Open questions
 
-What are some questions that you know aren't resolved yet by the KEP? These may be questions that could be answered through further discussion, implementation experiments, or anything else that the future may bring.
+What are some questions that you know aren't resolved yet by the KEP? 
+
+> These may be questions that could be answered through further discussion, implementation experiments, or anything else that the future may bring.
 
 ## Future possibilities
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+.vscode

--- a/0000-template.md
+++ b/0000-template.md
@@ -1,44 +1,50 @@
-# Replace this with your awesome KEP title
+# REPLACE this with your KEP title
 
-Short (one sentence) summary, e.g., something that would be appropriate for a [CHANGELOG](https://keepachangelog.com/) or release notes.
+Short one-sentence summary, i.e., a sentence that would be appropriate for a [CHANGELOG](https://keepachangelog.com/) or release note.
 
 ## Motivation
 
-Why should we make this change? What new value would it bring? What use cases does it enable?
+* Which use-cases does this KEP enable?
+* Which value would this KEP create?
 
 ## Explanation
 
-Explain the proposed change as though it was already implemented and you were explaining it to a user. Depending on which layer the proposal addresses, the "user" may vary, or there may even be multiple.
-
-We encourage you to use examples, diagrams, or whatever else makes the most sense!
+Explain the proposed change as though it was already implemented and you were explaining it to a user. Depending on which layer the proposal addresses, the "user" may vary or there may even be multiple.
+We encourage you to use examples, diagrams, or whatever else helps to explain the proposal.
 
 ## Internal details
 
-From a technical perspective, how do you propose accomplishing the proposal? In particular, please explain:
+From a technical perspective, how do you propose accomplishing the proposal? 
 
-* How the change would impact and interact with existing functionality
-* Likely error modes (and how to handle them)
-* Corner cases (and how to handle them)
+In particular, please explain:
 
-While you do not need to prescribe a particular implementation - indeed, KEPs should be about **behaviour**, not implementation! - it may be useful to provide at least one suggestion as to how the proposal *could* be implemented. This helps reassure reviewers that implementation is at least possible, and often helps them inspire them to think more deeply about trade-offs, alternatives, etc.
+* How would the change impact and interact with existing functionality?
+* Likely error modes and how to handle them
+* Corner cases and how to handle them
+
+While you do not need to prescribe a particular implementation - a KEP should be about **behavior**, not the implementation - it may be useful to provide at least one suggestion as to how the proposal *could* be implemented. This helps reassure reviewers that implementation is at least possible, and often helps them thinking more deeply about trade-offs, alternatives, etc.
 
 ## Trade-offs and mitigations
 
-What are some (known!) drawbacks? What are some ways that they might be mitigated?
+* What are some (known) drawbacks? 
+* What are some ways that they might be mitigated?
 
-Note that mitigations do not need to be complete *solutions*, and that they do not need to be accomplished directly through your proposal. A suggested mitigation may even warrant its own KEP!
+Note that mitigations do not need to be complete *solutions* and they do not need to be accomplished directly through your proposal. A suggested mitigation may even warrant its own KEP.
 
 ## Breaking changes
 
-Could this proposal cause any breaking changes (e.g., in the spec, within any workflows)?
+Could this proposal cause any breaking changes (e.g., in the spec or within any workflow)?
 
 ## Prior art and alternatives
 
-What are some prior and/or alternative approaches? For instance, is there a corresponding feature in OpenTracing or OpenCensus? What are some ideas that you have rejected?
+* What are some prior and/or alternative approaches? E.g., is there a corresponding feature in OpenTracing or OpenCensus? 
+* What are some ideas that you have rejected?
 
 ## Open questions
 
-What are some questions that you know aren't resolved yet by the KEP? These may be questions that could be answered through further discussion, implementation experiments, or anything else that the future may bring.
+What are some questions that you know aren't resolved yet by the KEP? 
+
+> These may be questions that could be answered through further discussion, implementation experiments, or anything else that the future may bring.
 
 ## Future possibilities
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,23 @@ On the other hand, they do not necessarily need to be used for such changes as:
 
 ## Writing a new proposal
 
+There are two options available for creating a KEP:
+
+* Forking the repo and creating a Pull Request
+* Creating an issue based on the KEP-template that contains the same content - we will then take care of the Pull Request
+
+**Preferred: Fork the repo and create a PR**
+
 1. [Fork](https://help.github.com/en/articles/fork-a-repo) the `keptn/enhancement-proposals` repo
 1. Copy `0000-template.md` into the [text/](text/) directory and rename it accordingly (e.g., to `XXXX-my-proposal-title.md`) - Please note that `XXXX` (ID of the KEP) needs to be replaced with the Pull Request ID later.
 1. Fill in the template. Put care into the details: It is important to present convincing motivation, demonstrate an understanding of the design's impact, and honestly assess the drawbacks and potential alternatives (feel free to adapt the template to your likings, if you feel that it is necessary or if it helps to improve readability).
+
+**Create an issue based on the KEP-template**
+
+1. [Create a new issue (based on the KEP-template)](https://github.com/keptn/enhancement-proposals/issues/new?assignees=&template=keptn-enhancement-proposal.md&title=KEP%20XXXX:%20Replace%20this%20with%20your%20awesome%20KEP%20title)
+1. Please note the ID of the issue and replace `XXXX` in the template with the issue ID.
+1. Fill in the template. Put care into the details: It is important to present convincing motivation, demonstrate an understanding of the design's impact, and honestly assess the drawbacks and potential alternatives (feel free to adapt the template to your likings, if you feel that it is necessary or if it helps to improve readability).
+1. Please note: For this KEP to be accepted, we will eventually create a Pull Request and merge it.
 
 ## Submitting a new proposal
 


### PR DESCRIPTION
This PR adds an issue template for KEPs.

I also added that into the README.md as a short-link (which will work once this template is merged into master)

Furthermore, based on Feedback from @johannes-b I have adapted the original template (0000-template.md)