### PR TITLE
KEP 56 - Resolving debt of SLI Retrieval

### DIFF
--- a/text/0056-sli-retrieval.md
+++ b/text/0056-sli-retrieval.md
@@ -1,0 +1,1 @@
+# SLI Retrieval


### PR DESCRIPTION
# Resolving Debt of SLI retrieval (> enabling Multi-SLI Provider Support)

## Short abstract
_Extend the Keptn quality gate capabilities by using the event handling functionality of Keptn (and not the lighthouse-service)._

## Why
### Target audience pain points

As an *SRE/DevOps engineer* using Keptn for implementing a quality gate in a delivery workflow:
* I would like to query SLIs from multiple SLI providers (e.g., Dynatrace, Prometheus, Splunk, etc.) which are then used in a quality gate evaluation.
* I would like to take the SLIs from a test execution, without querying a monitoring tool. For example, a Jmeter test already provides metrics about the response time. This information should be consumed by the quality gate evaluation without fetching the data from another tool, but rather taking it from the `evaluation` event payload.
* I would like to query data through a service that is running on an execution plane. (Currently, an SLI-provider must run on the Keptn control plane).   
* I would like to subscribe a custom SLI-provider to a `get-sli` event using the Keptn subscription mechanism. (Currently, the `keptn configure monitoring` command is used for this step.)
 
## Investment / Use-case drivers

* Enriching the Keptn *quality gate use-cases* by supporting the above-mentioned requirements.

_Open discussion_
* https://github.com/keptn/keptn/discussions/4672

## What

### What it is? What it is not?

* Resolving the design debt in the *lighthouse-service* that handles `get-sli` events. Due to this built-in functionality, limitations for certain use-cases (multi sli-provider support, running SLI-provider on execution-plane) exists. This is also the reason, why the `get-sli` task comes after `evaluation` what should be the other way around: 

![image](https://user-images.githubusercontent.com/729071/151383834-449a3c1a-cfe2-4a0e-8f84-553fd6f29d34.png)

* Deprecation of the `sh.keptn.event.monitoring.configure` event and the `keptn configure monitoring` command since the Uniform (event subscription) will manage which SLI-provider should react on a `get-sli` event. 

## Success criteria

Data from multiple SLI providers, as well as a testing tool that is part of a sequence execution, can be used for a quality gate evaluation. Additionally, an SLI provider can run on an execution plane. 

--- 

### Remarks
- This KEP uses the term **SLI-provider**. An SLI-provider is basically a typical Keptn-service that just listens on `get-sli` events. 
- ⚠️ This KEP uses the task name **get-sli**. However, this does not follow the naming schema of Keptn, as mentioned here: https://github.com/keptn/spec/issues/57 - Consider changing the name of the task as part of this KEP.

---

## Technical Implementation Details 

**Status quo:**
This section explains the current implementation of fetching SLIs from an SLI-provider. 

* Currently, the Shipyard looks as shown below, while the `evaluation` task encapsulates two types of events: (1) `get-sli.triggerd`, (2) `evaluation.triggered`
  ```
  apiVersion: "spec.keptn.sh/0.2.0"
  kind: "Shipyard"
  metadata:
    name: "shipyard-sockshop"
  spec:
    stages:
      - name: "dev"
        sequences:
          - name: "delivery"
            tasks:
              - name: "deployment"
              - name: "test"
              - name: "evaluation"
              - name: "release"
  ``` 
* The event handling for the `sh.keptn.event.get-sli.triggered` and `sh.keptn.event.get-sli.finished` events is managed by the *lighthouse-service*; which gets triggered by an `evaluation.triggered`
  * for `get-sli.triggered`: see: https://github.com/keptn/keptn/blob/master/lighthouse-service/event_handler/start_evaluation_handler.go#L56
  * for `get-sli.finished`: see https://github.com/keptn/keptn/blob/master/lighthouse-service/event_handler/evaluate_sli_handler.go#L69
* Since the event handling is in the *lighthouse-service*, these events are not exposed on the `​/event​/triggered​/{eventType}` endpoint of the *shipyard-controller*. Consequently, the SLI-provider has to run inside the Keptn control-plane for getting this type of event; running the SLI-provider on the execution-plane is not possible. 
* The *lighthouse-service* listens on a `sh.keptn.event.monitoring.configure` event to get the information which SLI-provider should be used. 
* The *lighthouse-service* has a dependency on the K8s API because for sending out a `get-sli` event the service derives the configured SLI provider first; see: https://github.com/keptn/keptn/blob/master/lighthouse-service/event_handler/start_evaluation_handler.go#L96

**Goal:**

* The handling of the `get-sli` event has to move from the *lighthouse-service* to the *shipyard-controller* to reuse the eventing capabilities of the *shipyard-controller*; meaning that, e.g., it will also be exposed for SLI-providers on the execution-plane. 
* This concludes that the Shipyard looks as follows: 
  ```
  apiVersion: "spec.keptn.sh/0.2.0"
  kind: "Shipyard"
  metadata:
    name: "shipyard-sockshop"
  spec:
    stages:
      - name: "dev"
        sequences:
          - name: "delivery"
            tasks:
              - name: "deployment"
              - name: "test"
              - name: "get-sli"                  <- explicitly mention the `get-sli` task
              - name: "evaluation"
              - name: "release"

  ```

* Backward compatibility: For ensuring backward compatibility, the following Shipyard *should* be supported: 
  ```
  apiVersion: "spec.keptn.sh/0.2.0"
  kind: "Shipyard"
  metadata:
    name: "shipyard-sockshop"
  spec:
    stages:
      - name: "dev"
        sequences:
          - name: "delivery"
            tasks:
              - name: "deployment"
              - name: "test"
              - name: "evaluation"
              - name: "release"
  ```
  * If no explicit `get-sli` task is mentioned, a *smart default* triggers this event before the `evaluation` task is executed. 

* Deprecate the `sh.keptn.event.monitoring.configure` event and the `keptn configure monitoring` command since the Uniform (event subscription) will manage which SLI-provider should react on a `get-sli` event. 

## User Cases

By moving the logic of the SLI retrieval from the *lighthouse-service* to the*shipyard-controller*, the following use cases are possible: 

### As a Keptn user, I would like to include multiple SLI-providers in a quality gate evaluation. 

When the `get-sli` task is part of a task sequence, multiple SLI-providers can subscribe to this task. The *shipyard-controller* will then take care of waiting for the subscribed SLI-providers before continuing with the `evaluation` task; a capability the *shipyard-controller* is capable of as of today. 

### As a Keptn user, I would like to run my SLI-provider on an execution-plane.

When the `get-sli` task is part of a task sequence, the *shipyard-controller* will provide a `get-sli.triggered` event on the `/event​/triggered​/{eventType}` endpoint. As a result, SLI-providers on the execution-plane can pull this event to fetch SLI when they are supposed to do. 

### As a Keptn user, I would expect that a quality gate evaluation considers the SLIs provided by a prior executed test.

This use case relates to this proposal: https://github.com/keptn/enhancement-proposals/issues/14

* Whit the implementation of this KEP, a test tool can return SLI values by adding an object consisting of `metric`, `value`, and `success` to the `[event].data.get-sli.indicatorValues` array. The same way a typical SLI-provider would do.
* The l*lighthouse-service* will then consider those values for the evaluation too.

```
{
  "specversion": "1.0",
  "id": "c4d3a334-6cb9-4e8c-a372-7e0b45942f53",
  "source": "source-service",
  "type": "sh.keptn.event.test.finished",
  "datacontenttype": "application/json",
  "data": {
    "project": "sockshop",
    "stage": "dev",
    "service": "carts",
    "get-sli": {
      "start": "2019-10-20T07:57:27.152330783Z",
      "end": "2019-10-22T08:57:27.152330783Z",
      "indicatorValues": [
        {
          "metric": "response_time_p50",
          "value": 1011.0745528937252,
          "success": true
        }
      ]
    }
  },
  "shkeptncontext": "a3e5f16d-8888-4720-82c7-6995062905c1",
  "triggeredid": "3f9640b6-1d2a-4f11-95f5-23259f1d82d6"
}
```
## Parts of the payload need to be discussed

The payload of the `get-sli.triggered` event is specified here: https://github.com/keptn/spec/blob/master/cloudevents.md#get-sli-triggered 

```
  "get-sli": {
    "sliProvider": "dynatrace",
    "start": "2019-10-28T15:44:27.152330783Z",
    "end": "2019-10-28T15:54:27.152330783Z",
    "indicators": [
      "throughput",
      "error_rate",
      "request_latency_p95"
    ],
    "customFilters": [
      {
        "key": "dynatraceEntityName",
        "value": "HealthCheckController"
      },
      {
        "key": "tags",
        "value": "test-subject:true"
      }
    ]
  }
```

1. The payload refers to the SLI-provider that is configured: `sliProvider` 
   * No need to send this information anymore. The user has to define by the Uniform (event subscription) which SLI-provider should gather SLIs. 
   * Consequently, the `keptn configure monitoring [dynatrace | prometheus]` will become deprecated.
1. The payload contains the `start`/`end` time to evaluate.
   * The SLI-provider needs to implement this functionality, which is currently implemented in the lighthouse-service. 
1. The payload contains information which is defined in the SLO.yaml: `indicators` and `customFilters` 
    * The SLIs provided all indicators from the SLI.yaml. If the lighthouse-service is missing an SLI, the service stops working with the error message: `Did not get all SLIs to evaluate the SLO`. 