### PR TITLE
KEP 60 - Role-based Access Control (RBAC)

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -1,56 +1,51 @@
-# Role-based Access Control (RBAC)
+# REPLACE this with your KEP title
 
-**Success Criteria:** Role-based and SSO-based access control need to be applied for accessing Keptn UIs and APIs.
+Short one-sentence summary, i.e., a sentence that would be appropriate for a [CHANGELOG](https://keepachangelog.com/) or release note.
 
 ## Motivation
 
-**Target audience pain points**
-As any user entering the Bridge, I see all and everything there from my whole organization. I see things, I do not care about and even worse: I might also see things I should not be allowed to see (e.g. QG results including security vulnerability metrics for a certain release).
+* Which use-cases does this KEP enable?
+* Which value would this KEP create?
 
-**Evidence**
-Keptn users requested role-based access to the Bridge several times.
+## Explanation
 
-No discussion, that role-based access and visibility of company data is a must-have for any enterprise-ready solution.
+Explain the proposed change as though it was already implemented and you were explaining it to a user. Depending on which layer the proposal addresses, the "user" may vary or there may even be multiple.
+We encourage you to use examples, diagrams, or whatever else helps to explain the proposal.
 
-## What
+## Internal details
 
-**What it is? What it is not?**
-* As anyone looking into data in the Bridge, I should only authenticate once and have proper permissions within the Bridge based on my SSO roles.
+From a technical perspective, how do you propose accomplishing the proposal? 
 
-* As an automation engineer, I should only edit the automation I'm responsible for.
+In particular, please explain:
 
-* As a member of one department, I might not be allowed to see (and not allowed to edit) quality gates of another department.
+* How would the change impact and interact with existing functionality?
+* Likely error modes and how to handle them
+* Corner cases and how to handle them
 
-## Use Cases
+While you do not need to prescribe a particular implementation - a KEP should be about **behavior**, not the implementation - it may be useful to provide at least one suggestion as to how the proposal *could* be implemented. This helps reassure reviewers that implementation is at least possible, and often helps them thinking more deeply about trade-offs, alternatives, etc.
 
-**Keptn has three roles: read / write / admin**
+## Trade-offs and mitigations
 
-* A read role allows you to:
-  * Read all resources without enabling you to modify a resource
+* What are some (known) drawbacks? 
+* What are some ways that they might be mitigated?
 
-* A write role allows you to:
-  * Modify all resources. E.g. approve a promotion in the bridge
-  * The "write" role for a given stage should only permit any modifications within the same stage. E.g. if you have the "write" role in dev, but not in hardening it should not allow you to press the "promote" button in dev, since then modifications are done in hardening.
+Note that mitigations do not need to be complete *solutions* and they do not need to be accomplished directly through your proposal. A suggested mitigation may even warrant its own KEP.
 
-* An admin role allows you to:
-  * Modify all resources, change the Keptn shipyard, create projects, ...
+## Breaking changes
 
-**Roles in Keptn must be settable on project- / service- / (stage+service)- level**
+Could this proposal cause any breaking changes (e.g., in the spec or within any workflow)?
 
-* Having a role on project-level enables you to perform an action in each stage for each service
-  * E.g. when having the write role for service X you can approve any approval step for service X in any stage
-  * Example use cases: define admins per project / give read permissions to business stakeholders
+## Prior art and alternatives
 
-* Having a role on service-level enables you to perform an action only for the given service (in each stage)
-  * E.g. when having the write role for service X you can approve any approval step for service X in any stage
-  * Example use case: All members of a team can promote a service to the next stage
+* What are some prior and/or alternative approaches? E.g., is there a corresponding feature in OpenTracing or OpenCensus? 
+* What are some ideas that you have rejected?
 
-* Having a role on (stage+service)-level enables you to perform an action only for the given stage/service tuple
-  * E.g. when having the write role for service X in stage Y you can only approve approval steps for service X in stage Y
-  * Example use case: Only a handful of people can approve the promotion of a service to production
+## Open questions
 
-**A role has one or more API tokens**
+What are some questions that you know aren't resolved yet by the KEP? 
 
-**The API tokens can be rotated**
+> These may be questions that could be answered through further discussion, implementation experiments, or anything else that the future may bring.
 
-* That's why we need multiple API tokens per role: We want to prevent that access is lost during the time the API token is rotated
+## Future possibilities
+
+What are some future changes that this proposal would enable?

--- a/0000-template.md
+++ b/0000-template.md
@@ -1,51 +1,56 @@
-# REPLACE this with your KEP title
+# Role-based Access Control (RBAC)
 
-Short one-sentence summary, i.e., a sentence that would be appropriate for a [CHANGELOG](https://keepachangelog.com/) or release note.
+**Success Criteria:** Role-based and SSO-based access control need to be applied for accessing Keptn UIs and APIs.
 
 ## Motivation
 
-* Which use-cases does this KEP enable?
-* Which value would this KEP create?
+**Target audience pain points**
+As any user entering the Bridge, I see all and everything there from my whole organization. I see things, I do not care about and even worse: I might also see things I should not be allowed to see (e.g. QG results including security vulnerability metrics for a certain release).
 
-## Explanation
+**Evidence**
+Keptn users requested role-based access to the Bridge several times.
 
-Explain the proposed change as though it was already implemented and you were explaining it to a user. Depending on which layer the proposal addresses, the "user" may vary or there may even be multiple.
-We encourage you to use examples, diagrams, or whatever else helps to explain the proposal.
+No discussion, that role-based access and visibility of company data is a must-have for any enterprise-ready solution.
 
-## Internal details
+## What
 
-From a technical perspective, how do you propose accomplishing the proposal? 
+**What it is? What it is not?**
+* As anyone looking into data in the Bridge, I should only authenticate once and have proper permissions within the Bridge based on my SSO roles.
 
-In particular, please explain:
+* As an automation engineer, I should only edit the automation I'm responsible for.
 
-* How would the change impact and interact with existing functionality?
-* Likely error modes and how to handle them
-* Corner cases and how to handle them
+* As a member of one department, I might not be allowed to see (and not allowed to edit) quality gates of another department.
 
-While you do not need to prescribe a particular implementation - a KEP should be about **behavior**, not the implementation - it may be useful to provide at least one suggestion as to how the proposal *could* be implemented. This helps reassure reviewers that implementation is at least possible, and often helps them thinking more deeply about trade-offs, alternatives, etc.
+## Use Cases
 
-## Trade-offs and mitigations
+**Keptn has three roles: read / write / admin**
 
-* What are some (known) drawbacks? 
-* What are some ways that they might be mitigated?
+* A read role allows you to:
+  * Read all resources without enabling you to modify a resource
 
-Note that mitigations do not need to be complete *solutions* and they do not need to be accomplished directly through your proposal. A suggested mitigation may even warrant its own KEP.
+* A write role allows you to:
+  * Modify all resources. E.g. approve a promotion in the bridge
+  * The "write" role for a given stage should only permit any modifications within the same stage. E.g. if you have the "write" role in dev, but not in hardening it should not allow you to press the "promote" button in dev, since then modifications are done in hardening.
 
-## Breaking changes
+* An admin role allows you to:
+  * Modify all resources, change the Keptn shipyard, create projects, ...
 
-Could this proposal cause any breaking changes (e.g., in the spec or within any workflow)?
+**Roles in Keptn must be settable on project- / service- / (stage+service)- level**
 
-## Prior art and alternatives
+* Having a role on project-level enables you to perform an action in each stage for each service
+  * E.g. when having the write role for service X you can approve any approval step for service X in any stage
+  * Example use cases: define admins per project / give read permissions to business stakeholders
 
-* What are some prior and/or alternative approaches? E.g., is there a corresponding feature in OpenTracing or OpenCensus? 
-* What are some ideas that you have rejected?
+* Having a role on service-level enables you to perform an action only for the given service (in each stage)
+  * E.g. when having the write role for service X you can approve any approval step for service X in any stage
+  * Example use case: All members of a team can promote a service to the next stage
 
-## Open questions
+* Having a role on (stage+service)-level enables you to perform an action only for the given stage/service tuple
+  * E.g. when having the write role for service X in stage Y you can only approve approval steps for service X in stage Y
+  * Example use case: Only a handful of people can approve the promotion of a service to production
 
-What are some questions that you know aren't resolved yet by the KEP? 
+**A role has one or more API tokens**
 
-> These may be questions that could be answered through further discussion, implementation experiments, or anything else that the future may bring.
+**The API tokens can be rotated**
 
-## Future possibilities
-
-What are some future changes that this proposal would enable?
+* That's why we need multiple API tokens per role: We want to prevent that access is lost during the time the API token is rotated

--- a/text/0060-rbac.md
+++ b/text/0060-rbac.md
@@ -1,51 +1,56 @@
-# REPLACE this with your KEP title
+# Role-based Access Control (RBAC)
 
-Short one-sentence summary, i.e., a sentence that would be appropriate for a [CHANGELOG](https://keepachangelog.com/) or release note.
+**Success Criteria:** Role-based and SSO-based access control need to be applied for accessing Keptn UIs and APIs.
 
 ## Motivation
 
-* Which use-cases does this KEP enable?
-* Which value would this KEP create?
+**Target audience pain points**
+As any user entering the Bridge, I see all and everything there from my whole organization. I see things, I do not care about and even worse: I might also see things I should not be allowed to see (e.g. QG results including security vulnerability metrics for a certain release).
 
-## Explanation
+**Evidence**
+Keptn users requested role-based access to the Bridge several times.
 
-Explain the proposed change as though it was already implemented and you were explaining it to a user. Depending on which layer the proposal addresses, the "user" may vary or there may even be multiple.
-We encourage you to use examples, diagrams, or whatever else helps to explain the proposal.
+No discussion, that role-based access and visibility of company data is a must-have for any enterprise-ready solution.
 
-## Internal details
+## What
 
-From a technical perspective, how do you propose accomplishing the proposal? 
+**What it is? What it is not?**
+* As anyone looking into data in the Bridge, I should only authenticate once and have proper permissions within the Bridge based on my SSO roles.
 
-In particular, please explain:
+* As an automation engineer, I should only edit the automation I'm responsible for.
 
-* How would the change impact and interact with existing functionality?
-* Likely error modes and how to handle them
-* Corner cases and how to handle them
+* As a member of one department, I might not be allowed to see (and not allowed to edit) quality gates of another department.
 
-While you do not need to prescribe a particular implementation - a KEP should be about **behavior**, not the implementation - it may be useful to provide at least one suggestion as to how the proposal *could* be implemented. This helps reassure reviewers that implementation is at least possible, and often helps them thinking more deeply about trade-offs, alternatives, etc.
+## Use Cases
 
-## Trade-offs and mitigations
+**Keptn has three roles: read / write / admin**
 
-* What are some (known) drawbacks? 
-* What are some ways that they might be mitigated?
+* A read role allows you to:
+  * Read all resources without enabling you to modify a resource
 
-Note that mitigations do not need to be complete *solutions* and they do not need to be accomplished directly through your proposal. A suggested mitigation may even warrant its own KEP.
+* A write role allows you to:
+  * Modify all resources. E.g. approve a promotion in the bridge
+  * The "write" role for a given stage should only permit any modifications within the same stage. E.g. if you have the "write" role in dev, but not in hardening it should not allow you to press the "promote" button in dev, since then modifications are done in hardening.
 
-## Breaking changes
+* An admin role allows you to:
+  * Modify all resources, change the Keptn shipyard, create projects, ...
 
-Could this proposal cause any breaking changes (e.g., in the spec or within any workflow)?
+**Roles in Keptn must be settable on project- / service- / (stage+service)- level**
 
-## Prior art and alternatives
+* Having a role on project-level enables you to perform an action in each stage for each service
+  * E.g. when having the write role for service X you can approve any approval step for service X in any stage
+  * Example use cases: define admins per project / give read permissions to business stakeholders
 
-* What are some prior and/or alternative approaches? E.g., is there a corresponding feature in OpenTracing or OpenCensus? 
-* What are some ideas that you have rejected?
+* Having a role on service-level enables you to perform an action only for the given service (in each stage)
+  * E.g. when having the write role for service X you can approve any approval step for service X in any stage
+  * Example use case: All members of a team can promote a service to the next stage
 
-## Open questions
+* Having a role on (stage+service)-level enables you to perform an action only for the given stage/service tuple
+  * E.g. when having the write role for service X in stage Y you can only approve approval steps for service X in stage Y
+  * Example use case: Only a handful of people can approve the promotion of a service to production
 
-What are some questions that you know aren't resolved yet by the KEP? 
+**A role has one or more API tokens**
 
-> These may be questions that could be answered through further discussion, implementation experiments, or anything else that the future may bring.
+**The API tokens can be rotated**
 
-## Future possibilities
-
-What are some future changes that this proposal would enable?
+* That's why we need multiple API tokens per role: We want to prevent that access is lost during the time the API token is rotated

--- a/text/0060-rbac.md
+++ b/text/0060-rbac.md
@@ -1,0 +1,51 @@
+# REPLACE this with your KEP title
+
+Short one-sentence summary, i.e., a sentence that would be appropriate for a [CHANGELOG](https://keepachangelog.com/) or release note.
+
+## Motivation
+
+* Which use-cases does this KEP enable?
+* Which value would this KEP create?
+
+## Explanation
+
+Explain the proposed change as though it was already implemented and you were explaining it to a user. Depending on which layer the proposal addresses, the "user" may vary or there may even be multiple.
+We encourage you to use examples, diagrams, or whatever else helps to explain the proposal.
+
+## Internal details
+
+From a technical perspective, how do you propose accomplishing the proposal? 
+
+In particular, please explain:
+
+* How would the change impact and interact with existing functionality?
+* Likely error modes and how to handle them
+* Corner cases and how to handle them
+
+While you do not need to prescribe a particular implementation - a KEP should be about **behavior**, not the implementation - it may be useful to provide at least one suggestion as to how the proposal *could* be implemented. This helps reassure reviewers that implementation is at least possible, and often helps them thinking more deeply about trade-offs, alternatives, etc.
+
+## Trade-offs and mitigations
+
+* What are some (known) drawbacks? 
+* What are some ways that they might be mitigated?
+
+Note that mitigations do not need to be complete *solutions* and they do not need to be accomplished directly through your proposal. A suggested mitigation may even warrant its own KEP.
+
+## Breaking changes
+
+Could this proposal cause any breaking changes (e.g., in the spec or within any workflow)?
+
+## Prior art and alternatives
+
+* What are some prior and/or alternative approaches? E.g., is there a corresponding feature in OpenTracing or OpenCensus? 
+* What are some ideas that you have rejected?
+
+## Open questions
+
+What are some questions that you know aren't resolved yet by the KEP? 
+
+> These may be questions that could be answered through further discussion, implementation experiments, or anything else that the future may bring.
+
+## Future possibilities
+
+What are some future changes that this proposal would enable?


### PR DESCRIPTION
# Role-based Access Control (RBAC)

**Success Criteria:** Role-based and SSO-based access control need to be applied for accessing Keptn UIs and APIs.

## Motivation

**Target audience pain points**
As any user entering the Bridge, I see all and everything there from my whole organization. I see things, I do not care about and even worse: I might also see things I should not be allowed to see (e.g. QG results including security vulnerability metrics for a certain release).

**Evidence**
Keptn users requested role-based access to the Bridge several times.

No discussion, that role-based access and visibility of company data is a must-have for any enterprise-ready solution.

## What

**What it is?**
* As anyone looking into data in the Bridge, I should only authenticate once and have proper permissions within the Bridge based on my SSO roles.

* As an automation engineer, I should only edit the automation I'm responsible for.

* As a member of one department, I might not be allowed to see (and not allowed to edit) quality gates of another department.

**What it is not**

## Use Cases

#### As an operator of Keptn, I can connect it to my OIDC/OAuth 2.0 provider (e.g, Keycloak, Okta, etc.)

#### Keptn has three roles: read / write / admin

* A read role allows you to:
  * Read all resources without enabling you to modify a resource

* A write role allows you to:
  * Modify all resources. E.g. approve a promotion in the bridge
  * The "write" role for a given stage should only permit any modifications within the same stage. E.g. if you have the "write" role in dev, but not in hardening it should not allow you to press the "promote" button in dev, since then modifications are done in hardening.

* An admin role allows you to:
  * Modify all resources, change the Keptn shipyard, create projects, ...

#### Roles in Keptn must be settable on project- / service- / (stage+service)- level

* Having a role on project-level enables you to perform an action in each stage for each service
  * E.g. when having the write role for service X you can approve any approval step for service X in any stage
  * Example use cases: define admins per project / give read permissions to business stakeholders

* Having a role on service-level enables you to perform an action only for the given service (in each stage)
  * E.g. when having the write role for service X you can approve any approval step for service X in any stage
  * Example use case: All members of a team can promote a service to the next stage

* Having a role on (stage+service)-level enables you to perform an action only for the given stage/service tuple
  * E.g. when having the write role for service X in stage Y you can only approve approval steps for service X in stage Y
  * Example use case: Only a handful of people can approve the promotion of a service to production

#### A role has one or more API tokens

#### The API tokens can be rotated

* That's why we need multiple API tokens per role: We want to prevent that access is lost during the time the API token is rotated

## Slices of this KEP

This KEP is currently sliced into three epics: 

* 1. Authentication: [Support OIDC/OAuth2.0](https://github.com/keptn/enhancement-proposals/pull/60#issuecomment-990900264) [status: done ]
* 2. Local authorization for a read, write, admin user: [status is in refinement]
* 3. Full RBAC Authorization Management inside Keptn: [status is in refinement]