### PR TITLE
Remove johannes-b from code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @AloisReitbauer @christian-kreuzberger-dtx @johannes-b
+* @AloisReitbauer @christian-kreuzberger-dtx


### PR DESCRIPTION
Please remove myself from being a CodeOwner - thank you!

Signed-off-by: Johannes Bräuer <johannes.braeuer@gmx.at>