### PR TITLE
doc: add GC members to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @AloisReitbauer @christian-kreuzberger-dtx @johannes-b
+* @AloisReitbauer @AlexsJones @AnaMMedina21


### PR DESCRIPTION
Signed-off-by: Thomas Schuetz <thomas.schuetz@dynatrace.com>